### PR TITLE
[dnsrocks] fix race in stats.go

### DIFF
--- a/dnsrocks/metrics/stats.go
+++ b/dnsrocks/metrics/stats.go
@@ -105,9 +105,12 @@ func (stats *Stats) AddSample(key string, value int64) {
 // Get implements export.Int interface
 func (stats *Stats) Get() map[string]int64 {
 	var ret = make(map[string]int64)
+	stats.vlock.Lock()
 	for key, val := range stats.values {
 		ret[key] = val
 	}
+	stats.vlock.Unlock()
+	stats.wlock.Lock()
 	for key, val := range stats.windows {
 		samples := val.Samples()
 		sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
@@ -125,6 +128,6 @@ func (stats *Stats) Get() map[string]int64 {
 			ret[fmt.Sprintf("%s.avg", key)] = 0
 		}
 	}
-
+	stats.wlock.Unlock()
 	return ret
 }


### PR DESCRIPTION

**What:**

Fix data race caught by test suite


**How:**

Lock on read
**Risks:**
Less, than data races
**Checklist**:




- [] Added tests, if you've added code that should be tested N/A
- [ ] Updated the documentation, if you've changed APIs N/A
- [x] Ensured the test suite passes 
- [x] Made sure your code lints
- [x] Completed the Contributor License Agreement ("CLA")


<!-- feel free to add additional comments -->


Testplan:
```
 death0wl@death0wl-fedora-PF20THNE  ~/work/dns/dnsrocks   racerace ±  CGO_LDFLAGS_ALLOW=".*" CGO_CFLAGS_ALLOW=".*" go test  -race ./...
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
# github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb
cc1: warning: command-line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
ok  	github.com/facebookincubator/dns/dnsrocks/cgo-rocksdb	2.255s
?   	github.com/facebookincubator/dns/dnsrocks/cmd/cdbdumpstats	[no test files]
ok  	github.com/facebookincubator/dns/dnsrocks/cmd/dnsrocks	5.237s
?   	github.com/facebookincubator/dns/dnsrocks/cmd/dnsrocks-applyrdb	[no test files]
?   	github.com/facebookincubator/dns/dnsrocks/cmd/dnsrocks-backuprdb	[no test files]
?   	github.com/facebookincubator/dns/dnsrocks/cmd/dnsrocks-data	[no test files]
?   	github.com/facebookincubator/dns/dnsrocks/cmd/dnsrocks-ecscmp	[no test files]
?   	github.com/facebookincubator/dns/dnsrocks/cmd/dnsrocks-from-bind	[no test files]
?   	github.com/facebookincubator/dns/dnsrocks/cmd/dnsrocks-get	[no test files]
?   	github.com/facebookincubator/dns/dnsrocks/cmd/dnsrocks-mkcdb	[no test files]
?   	github.com/facebookincubator/dns/dnsrocks/cmd/dnsrocks-preproc	[no test files]
?   	github.com/facebookincubator/dns/dnsrocks/cmd/dnsrocks-selftest	[no test files]
ok  	github.com/facebookincubator/dns/dnsrocks/db	0.769s
ok  	github.com/facebookincubator/dns/dnsrocks/dnsdata	10.994s
ok  	github.com/facebookincubator/dns/dnsrocks/dnsdata/cdb	0.068s
ok  	github.com/facebookincubator/dns/dnsrocks/dnsdata/quote	0.054s
ok  	github.com/facebookincubator/dns/dnsrocks/dnsdata/rdb	0.152s
ok  	github.com/facebookincubator/dns/dnsrocks/dnsdata/rdb/dbdiff	0.037s
ok  	github.com/facebookincubator/dns/dnsrocks/dnsdata/rdb_test	0.363s
ok  	github.com/facebookincubator/dns/dnsrocks/dnsdata/svcb	0.045s
ok  	github.com/facebookincubator/dns/dnsrocks/dnsserver	0.672s
?   	github.com/facebookincubator/dns/dnsrocks/dnsserver/stats	[no test files]
?   	github.com/facebookincubator/dns/dnsrocks/dnsserver/test	[no test files]
ok  	github.com/facebookincubator/dns/dnsrocks/fbserver	7.239s
ok  	github.com/facebookincubator/dns/dnsrocks/logger	0.043s
ok  	github.com/facebookincubator/dns/dnsrocks/metrics	13.060s
?   	github.com/facebookincubator/dns/dnsrocks/testaid	[no test files]
?   	github.com/facebookincubator/dns/dnsrocks/testutils	[no test files]
ok  	github.com/facebookincubator/dns/dnsrocks/tlsconfig	1.332s
ok  	github.com/facebookincubator/dns/dnsrocks/whoami	0.047s
```
