### PR TITLE
Move presentation logic to a new `Values` type.

### DIFF
--- a/dnsrocks/debuginfo/debuginfo_test.go
+++ b/dnsrocks/debuginfo/debuginfo_test.go
@@ -66,20 +66,16 @@ func TestWithoutECS(t *testing.T) {
 			info := infoSrc.GetInfo(state)
 
 			// Check timestamp
-			require.Equal(t, info[0].Key, "time", "missing time key")
-			created, err := strconv.ParseFloat(info[0].Val, 64)
+			require.True(t, info.Has("time"), "missing time key")
+			created, err := strconv.ParseFloat(info.Get("time"), 64)
 			require.NoError(t, err, "time is not a valid float")
 			createdMillis := int64(created * 1000)
 			require.Less(t, before, createdMillis, "creation time is too early")
 			require.Less(t, createdMillis, after, "creation time is too late")
 			// Check other info
-			info = info[1:]
-			expected := []Pair{
-				{"protocol", "UDP"},
-				{"source", tc.remoteIPResp},
-				{"destination", w.LocalAddr().String()},
-			}
-			require.Equal(t, info[:len(expected)], expected, "wrong info output")
+			require.Equal(t, "UDP", info.Get("protocol"))
+			require.Equal(t, tc.remoteIPResp, info.Get("source"))
+			require.Equal(t, w.LocalAddr().String(), info.Get("destination"))
 		})
 	}
 }
@@ -132,15 +128,11 @@ func TestWithECS(t *testing.T) {
 
 			info := Generator(false)().GetInfo(state)
 
-			require.Equal(t, info[0].Key, "time", "missing time key")
-			info = info[1:]
-			expected := []Pair{
-				{"protocol", "UDP"},
-				{"source", tc.remoteIPResp},
-				{"destination", w.LocalAddr().String()},
-				{"ecs", tc.ecsResp},
-			}
-			require.Equal(t, info[:len(expected)], expected, "wrong info output")
+			require.True(t, info.Has("time"), "missing time key")
+			require.Equal(t, "UDP", info.Get("protocol"), "wrong protocol")
+			require.Equal(t, tc.remoteIPResp, info.Get("source"), "wrong source IP")
+			require.Equal(t, w.LocalAddr().String(), info.Get("destination"), "wrong destination IP")
+			require.Equal(t, tc.ecsResp, info.Get("ecs"), "wrong ECS tag")
 		})
 	}
 }

--- a/dnsrocks/debuginfo/values.go
+++ b/dnsrocks/debuginfo/values.go
@@ -1,0 +1,83 @@
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debuginfo
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/coredns/coredns/request"
+)
+
+// Pair represents a key-value pair of debug info.
+// It is used instead of a map in order to provide a
+// stable output order for metadata.
+type Pair struct {
+	Key string
+	Val string
+}
+
+// Values is inspired by [url.Values], but is simplified for this use case:
+//   - Percent-encoding is not used.  This keeps IPv6 addresses human-readable
+//     and reduces response bloat.
+//   - Keys with empty values are omitted from the encoded output.
+//   - Stable-order iteration is available independent of the syntax, to support
+//     TXT record generation, but sorting is avoided.  This makes lookups slow,
+//     but the lookup methods are only used in the tests.
+type Values []Pair
+
+// Add appends a key-val pair to the Values.
+func (v *Values) Add(key string, val string) {
+	*v = append(*v, Pair{Key: key, Val: val})
+}
+
+// Encode returns the values encoded in key=value style (similar to DNS-SD).
+func (v *Values) Encode() string {
+	var components []string
+	for _, pair := range *v {
+		if len(pair.Val) > 0 {
+			components = append(components, fmt.Sprintf("%s=%s", pair.Key, pair.Val))
+		}
+	}
+	return strings.Join(components, " ")
+}
+
+// Has returns true if at least one value exists for this key.
+func (v *Values) Has(key string) bool {
+	for _, pair := range *v {
+		if pair.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+// Get returns the first value associated with this key.
+func (v *Values) Get(key string) string {
+	for _, pair := range *v {
+		if pair.Key == key {
+			return pair.Val
+		}
+	}
+	return ""
+}
+
+// MockInfoSrc is a mock [InfoSrc] used for testing.
+type MockInfoSrc Values
+
+// GetInfo implements the [InfoSrc] interface.
+func (s *MockInfoSrc) GetInfo(request.Request) *Values {
+	v := Values(*s)
+	return &v
+}

--- a/dnsrocks/debuginfo/values_test.go
+++ b/dnsrocks/debuginfo/values_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debuginfo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdd(t *testing.T) {
+	v := new(Values)
+	v.Add("foo", "bar")
+	require.Equal(t, []Pair{{Key: "foo", Val: "bar"}}, []Pair(*v))
+}
+
+func TestEncode(t *testing.T) {
+	v := new(Values)
+	v.Add("foo", "bar")
+	v.Add("123", "456")
+	require.Equal(t, "foo=bar 123=456", v.Encode())
+}
+
+func TestGet(t *testing.T) {
+	v := new(Values)
+	v.Add("foo", "bar")
+	require.Equal(t, "bar", v.Get("foo"))
+	require.Empty(t, v.Get("not present"))
+}
+
+func TestHas(t *testing.T) {
+	v := new(Values)
+	v.Add("foo", "bar")
+	require.True(t, v.Has("foo"))
+	require.False(t, v.Has("not present"))
+}
+
+func TestEmptyValue(t *testing.T) {
+	v := new(Values)
+	v.Add("empty-value", "")
+	require.True(t, v.Has("empty-value"))
+	require.Empty(t, v.Encode())
+}

--- a/dnsrocks/nsid/nsid.go
+++ b/dnsrocks/nsid/nsid.go
@@ -67,7 +67,7 @@ func (w nsidResponseWriter) WriteMsg(response *dns.Msg) error {
 		glog.Errorf("no EDNS for NSID")
 	} else {
 		state := request.Request{W: w, Req: w.request}
-		nsid := debuginfo.Print(w.infoSrc.GetInfo(state))
+		nsid := w.infoSrc.GetInfo(state).Encode()
 		opt.Option = append(opt.Option, &dns.EDNS0_NSID{
 			Code: dns.EDNS0NSID,
 			Nsid: hex.EncodeToString([]byte(nsid)),

--- a/dnsrocks/nsid/nsid_test.go
+++ b/dnsrocks/nsid/nsid_test.go
@@ -21,19 +21,12 @@ import (
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
-	"github.com/coredns/coredns/request"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/facebook/dns/dnsrocks/debuginfo"
 )
-
-type mockInfo []debuginfo.Pair
-
-func (i mockInfo) GetInfo(_ request.Request) []debuginfo.Pair {
-	return i
-}
 
 func TestNSID(t *testing.T) {
 	w := &test.ResponseWriter{}
@@ -49,10 +42,11 @@ func TestNSID(t *testing.T) {
 	var infoTime time.Time
 	h.infoGen = func() debuginfo.InfoSrc {
 		infoTime = time.Now()
-		return mockInfo([]debuginfo.Pair{
+		src := debuginfo.MockInfoSrc([]debuginfo.Pair{
 			{Key: "foo1", Val: "bar1"},
 			{Key: "foo2", Val: "bar2"},
 		})
+		return &src
 	}
 	var responseTime time.Time
 	h.Next = test.HandlerFunc(func(c context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {

--- a/dnsrocks/whoami/whoami.go
+++ b/dnsrocks/whoami/whoami.go
@@ -59,8 +59,11 @@ func (wh *Handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 			rr.(*dns.TXT).Txt = []string{fmt.Sprintf("%s %s", key, value)}
 			return rr
 		}
-		for _, pair := range wh.infoGen().GetInfo(state) {
-			m.Answer = append(m.Answer, mkTxt(pair.Key, pair.Val))
+		info := wh.infoGen().GetInfo(state)
+		for _, pair := range *info {
+			if len(pair.Val) > 0 {
+				m.Answer = append(m.Answer, mkTxt(pair.Key, pair.Val))
+			}
 		}
 	}
 

--- a/dnsrocks/whoami/whoami_test.go
+++ b/dnsrocks/whoami/whoami_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
-	"github.com/coredns/coredns/request"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/require"
 
@@ -30,12 +29,6 @@ import (
 
 func makeWhoamiDomain(s string) string {
 	return strings.ToLower(dns.Fqdn(s))
-}
-
-type mockInfo []debuginfo.Pair
-
-func (i mockInfo) GetInfo(_ request.Request) []debuginfo.Pair {
-	return i
 }
 
 // TestHandlerBadType tests that we return noerror/nodata
@@ -71,7 +64,8 @@ func TestHandlerValidRequest(t *testing.T) {
 	var creationTime time.Time
 	wh.infoGen = func() debuginfo.InfoSrc {
 		creationTime = time.Now()
-		return mockInfo(expectedAnswers)
+		src := debuginfo.MockInfoSrc(expectedAnswers)
+		return &src
 	}
 
 	before := time.Now()


### PR DESCRIPTION
Summary: Represent the debug info as a `Values` type modeled on `url.Values`.  This is a pure refactor with no meaningful behavior change.

Reviewed By: leoleovich

Differential Revision: D47997264

