### PR TITLE
rocksdb: add WaitForCompact()

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ on: [push, pull_request]
 jobs:
   lint:
     runs-on: ubuntu-22.04
+    env:
+      CGO_LDFLAGS_ALLOW: .*
+      CGO_CFLAGS_ALLOW: .*
     steps:
       - uses: actions/checkout@v2
         with:
@@ -10,8 +13,8 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.18
-      - name: "Install Rocks"
-        run: sudo bash .github/scripts/install_rocks_stable.sh
+      - name: "Install RocksDB"
+        run: sudo bash .github/scripts/install_rocks_head.sh
       - uses: golangci/golangci-lint-action@v3
         with:
           working-directory: dnsrocks

--- a/dnsrocks/cgo-rocksdb/db.go
+++ b/dnsrocks/cgo-rocksdb/db.go
@@ -341,6 +341,17 @@ func (db *RocksDB) CompactRangeAll() {
 	)
 }
 
+// WaitForCompact waits for all currently running compactions to finish, optionally closing the DB afterwards
+func (db *RocksDB) WaitForCompact(options *WaitForCompactOptions) error {
+	var cError *C.char
+	C.rocksdb_wait_for_compact(db.cDB, options.cOptions, &cError)
+	if cError != nil {
+		defer C.rocksdb_free(unsafe.Pointer(cError))
+		return errors.New(C.GoString(cError))
+	}
+	return nil
+}
+
 // GetProperty returns value of db property
 func (db *RocksDB) GetProperty(prop string) string {
 	cprop := C.CString(prop)

--- a/dnsrocks/docs/building.md
+++ b/dnsrocks/docs/building.md
@@ -1,7 +1,7 @@
 # Building DNSRocks
 
 ## Prerequisites
-- [Rocksdb](https://github.com/facebook/rocksdb/releases) 7.3 or newer
+- [Rocksdb](https://github.com/facebook/rocksdb/releases) 8.7 or newer
 - [Go 1.18](https://github.com/facebook/dns/blob/main/dnsrocks/go.mod#L3)
 
 


### PR DESCRIPTION
Summary: RocksDB 8.7 was released with C bindings for `WaitForCompact()` call that was added on our request. Update CGO wrapper with those bindings.

Reviewed By: leoleovich

Differential Revision: D51029439


