### PR TITLE
use rocksdb WaitForCompact()

### DIFF
--- a/dnsrocks/dnsdata/rdb/rdb_test.go
+++ b/dnsrocks/dnsdata/rdb/rdb_test.go
@@ -86,6 +86,10 @@ func (mock *mockedDB) GetProperty(string) string {
 	return ""
 }
 
+func (mock *mockedDB) WaitForCompact(*rocksdb.WaitForCompactOptions) error {
+	return nil
+}
+
 func TestRDBAddErrorGettingValue(t *testing.T) {
 	// check that returns error
 	errorMsg := "I CAN'T GET NO VALUE"


### PR DESCRIPTION
Summary: Use latest and greatest `WaitForCompact()` that was added on our request instead of polling for compaction stats.

Reviewed By: deathowl

Differential Revision: D48355674

