### PR TITLE
Fix socket port number tracing for TCP

### DIFF
--- a/dnswatch/bpf/dnswatch.bpf.c
+++ b/dnswatch/bpf/dnswatch.bpf.c
@@ -120,7 +120,7 @@ int BPF_PROG(dnswatch_kprobe_tcp_sendmsg, struct sock* sk, struct msghdr* msg) {
   dport = sk->__sk_common.skc_dport;
   sport = sk->__sk_common.skc_num;
 
-  return sendmsg_solver(ctx, 2, dport, dport);
+  return sendmsg_solver(ctx, 2, dport, sport);
 }
 
 char LICENSE[] SEC("license") = "GPL";


### PR DESCRIPTION
Probe UDP and TCP messages the same way by passing the socket port number of the TCP message to the `sendmsg_solver` function.