### PR TITLE
significantly improve DB compilation speed

### DIFF
--- a/dnsrocks/dnsdata/rdb/rdb_compiler.go
+++ b/dnsrocks/dnsdata/rdb/rdb_compiler.go
@@ -74,7 +74,7 @@ func compileBuilder(in io.Reader, codec *dnsdata.Codec, destPath string, opts Co
 
 	store := func(data []dnsdata.MapRecord) {
 		for _, m := range data {
-			builder.ScheduleAdd(m.Key, m.Value)
+			builder.ScheduleAdd(m)
 			nw++
 			counter++
 			if counter == DefaultBatchSize {

--- a/dnsrocks/dnsdata/rdb/rdb_util.go
+++ b/dnsrocks/dnsdata/rdb/rdb_util.go
@@ -23,6 +23,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/facebook/dns/dnsrocks/dnsdata"
 )
 
 var (
@@ -121,4 +123,27 @@ func rdbStats(q string) map[string]int64 {
 		}
 	}
 	return stats
+}
+
+// merge merges two sorted lists of records
+func merge(a []*dnsdata.MapRecord, b []*dnsdata.MapRecord) []*dnsdata.MapRecord {
+	result := make([]*dnsdata.MapRecord, 0, len(a)+len(b))
+	i := 0
+	j := 0
+	for i < len(a) && j < len(b) {
+		if keyOrder(a[i], b[j]) < 0 {
+			result = append(result, a[i])
+			i++
+		} else {
+			result = append(result, b[j])
+			j++
+		}
+	}
+	for ; i < len(a); i++ {
+		result = append(result, a[i])
+	}
+	for ; j < len(b); j++ {
+		result = append(result, b[j])
+	}
+	return result
 }

--- a/dnsrocks/go.mod
+++ b/dnsrocks/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.13.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/repustate/go-cdb v0.0.0-20160430174706-6a418fad95e2
+	github.com/segmentio/fasthash v1.0.3
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
 	golang.org/x/sync v0.1.0

--- a/dnsrocks/go.sum
+++ b/dnsrocks/go.sum
@@ -228,6 +228,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
+github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=


### PR DESCRIPTION
Summary:
Our bottleneck was unsurprisingly in sorting the entire dataset, which of course is CPU bound and single-threaded.

But we don't need to do it like this.

The reason we did so was to be able to guarantee that same keys end up in same buckets, combined with RocksDB requirement for data being [pre-sorted when we use SST ingestion](https://github.com/facebook/rocksdb/wiki/Creating-and-Ingesting-SST-files).

Instead, with this change, we use fast hashing to put same keys into the same buckets, and sort each bucket separately, in parallel, so it's ready for ingestion.

The result is a significant speedup in DB compilation, up to 2x for big shards.

Reviewed By: t3lurid3

Differential Revision: D54191772


