### PR TITLE
bump dnsrocks go to 1.22

### DIFF
--- a/dnsrocks/go.mod
+++ b/dnsrocks/go.mod
@@ -1,6 +1,6 @@
 module github.com/facebook/dns/dnsrocks
 
-go 1.18
+go 1.22
 
 require (
 	github.com/coredns/coredns v1.10.0


### PR DESCRIPTION
Summary: Same as in prod

Differential Revision: D54195745


