### PR TITLE
lint after Go 1.22

### DIFF
--- a/dnsrocks/cmd/cdbdumpstats/cdbdumpstats.go
+++ b/dnsrocks/cmd/cdbdumpstats/cdbdumpstats.go
@@ -48,7 +48,7 @@ func main() {
 
 	if *dumbSlotStats {
 		slotstats := make(map[uint32]int)
-		err := c.ForEachKeys(func(keyHash uint32, key, value []byte) {
+		err := c.ForEachKeys(func(keyHash uint32, _, _ []byte) {
 			slotstats[keyHash]++
 		})
 		if err != nil {

--- a/dnsrocks/db/answer_sorted.go
+++ b/dnsrocks/db/answer_sorted.go
@@ -149,7 +149,7 @@ func (r *sortedDataReader) IsAuthoritative(q []byte, loc *Location) (ns bool, au
 
 	var zoneCutLength int
 
-	preIterationCheck := func(q []byte, qLength int) bool {
+	preIterationCheck := func(_ []byte, qLength int) bool {
 		zoneCutLength = qLength
 
 		return true

--- a/dnsrocks/db/db.go
+++ b/dnsrocks/db/db.go
@@ -244,7 +244,7 @@ func (f *DB) ValidateDbKey(dbKey []byte) error {
 		err      error
 		keyFound bool
 	)
-	parseResult := func(result []byte) error {
+	parseResult := func(_ []byte) error {
 		// set to true as soon as first key found
 		keyFound = true
 		return nil

--- a/dnsrocks/db/db_test.go
+++ b/dnsrocks/db/db_test.go
@@ -154,7 +154,7 @@ func TestDbReload(t *testing.T) {
 	// DB is closed, and there is no error
 	mockDbiValid := getBaseMockDBI(ctrl)
 	// simulates a key hit by returning a value on first call to FindNext, followed by an EOF
-	foreachCallback := func(key []byte, f func(value []byte) error, context Context) error {
+	foreachCallback := func(_ []byte, f func(value []byte) error, _ Context) error {
 		err := f([]byte("{}"))
 		return err
 	}

--- a/dnsrocks/dnsdata/rdb/rdb_test.go
+++ b/dnsrocks/dnsdata/rdb/rdb_test.go
@@ -95,10 +95,10 @@ func TestRDBAddErrorGettingValue(t *testing.T) {
 	errorMsg := "I CAN'T GET NO VALUE"
 	rdb := &RDB{
 		db: &mockedDB{
-			get: func(key []byte) ([]byte, error) {
+			get: func(_ []byte) ([]byte, error) {
 				return nil, errors.New(errorMsg)
 			},
-			put: func(key, value []byte) error {
+			put: func(_, _ []byte) error {
 				return nil
 			},
 		},
@@ -116,7 +116,7 @@ func TestRDBAddToNewKey(t *testing.T) {
 	newValue := []byte{1, 2, 255, 3, 0}
 	rdb := &RDB{
 		db: &mockedDB{
-			get: func(key []byte) ([]byte, error) {
+			get: func(_ []byte) ([]byte, error) {
 				return nil, nil
 			},
 			put: func(key, value []byte) error {
@@ -137,7 +137,7 @@ func TestRDBAddErrorAddToExistingKey(t *testing.T) {
 	newValue := []byte{8, 2, 255, 3, 9, 8, 9}
 	rdb := &RDB{
 		db: &mockedDB{
-			get: func(key []byte) ([]byte, error) {
+			get: func(_ []byte) ([]byte, error) {
 				return oldValue, nil
 			},
 			put: func(key, value []byte) error {
@@ -165,7 +165,7 @@ func TestRDBDelErrorGettingKey(t *testing.T) {
 	errorMsg := "I CAN'T GET NO VALUE"
 	rdb := &RDB{
 		db: &mockedDB{
-			get: func(key []byte) ([]byte, error) {
+			get: func(_ []byte) ([]byte, error) {
 				return nil, errors.New(errorMsg)
 			},
 		},
@@ -181,7 +181,7 @@ func TestRDBDelErrorMissingKey(t *testing.T) {
 	// check that returns error if key does not exist
 	rdb := &RDB{
 		db: &mockedDB{
-			get: func(key []byte) ([]byte, error) {
+			get: func(_ []byte) ([]byte, error) {
 				return nil, nil
 			},
 		},
@@ -206,11 +206,11 @@ func TestRDBDelErrorNonExistingValue(t *testing.T) {
 				require.Equal(t, key, simpleKey)
 				return simpleValStored, nil
 			},
-			put: func(key, value []byte) error {
+			put: func(_, _ []byte) error {
 				t.Error("Should not be called")
 				return nil
 			},
-			delete: func(key []byte) error {
+			delete: func(_ []byte) error {
 				deleteCalled = true
 				return nil
 			},
@@ -237,11 +237,11 @@ func TestRDBDelErrorTruncatedValue1(t *testing.T) {
 				require.Equal(t, key, simpleKey)
 				return simpleValStored, nil
 			},
-			put: func(key, value []byte) error {
+			put: func(_, _ []byte) error {
 				t.Error("Should not be called")
 				return nil
 			},
-			delete: func(key []byte) error {
+			delete: func(_ []byte) error {
 				deleteCalled = true
 				return nil
 			},
@@ -268,11 +268,11 @@ func TestRDBDelErrorTruncatedValue2(t *testing.T) {
 				require.Equal(t, key, simpleKey)
 				return simpleValStored, nil
 			},
-			put: func(key, value []byte) error {
+			put: func(_, _ []byte) error {
 				t.Error("Should not be called")
 				return nil
 			},
-			delete: func(key []byte) error {
+			delete: func(_ []byte) error {
 				deleteCalled = true
 				return nil
 			},
@@ -298,7 +298,7 @@ func TestRDBDelOnlyValue(t *testing.T) {
 				require.Equal(t, key, simpleKey)
 				return simpleValStored, nil
 			},
-			put: func(key, value []byte) error {
+			put: func(_, _ []byte) error {
 				t.Error("Should not be called")
 				return nil
 			},
@@ -367,7 +367,7 @@ func TestRDBDelWithOffset(t *testing.T) {
 					require.Equal(t, test.after, value)
 					return nil
 				},
-				delete: func(key []byte) error {
+				delete: func(_ []byte) error {
 					t.Error("Should not be called")
 					return nil
 				},
@@ -561,11 +561,11 @@ func TestRDBContext(t *testing.T) {
 					require.Equal(t, simpleKey, key)
 					return test.data, nil
 				},
-				put: func(key, value []byte) error {
+				put: func(_, _ []byte) error {
 					t.Error("Should not be called")
 					return nil
 				},
-				delete: func(key []byte) error {
+				delete: func(_ []byte) error {
 					t.Error("Should not be called")
 					return nil
 				},
@@ -817,19 +817,19 @@ func TestRDBFindFirst(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", nt), func(t *testing.T) {
 			rdb := &RDB{
 				db: &mockedDB{
-					getMulti: func(readOptions *rocksdb.ReadOptions, keys [][]byte) ([][]byte, []error) {
+					getMulti: func(_ *rocksdb.ReadOptions, keys [][]byte) ([][]byte, []error) {
 						require.Equal(t, keys, test.requestedKeys)
 						return test.getMultiValues, test.getMultiErrors
 					},
-					get: func(key []byte) ([]byte, error) {
+					get: func(_ []byte) ([]byte, error) {
 						t.Error("Should not be called")
 						return nil, nil
 					},
-					put: func(key, value []byte) error {
+					put: func(_, _ []byte) error {
 						t.Error("Should not be called")
 						return nil
 					},
-					delete: func(key []byte) error {
+					delete: func(_ []byte) error {
 						t.Error("Should not be called")
 						return nil
 					},

--- a/dnsrocks/nsid/nsid_test.go
+++ b/dnsrocks/nsid/nsid_test.go
@@ -49,7 +49,7 @@ func TestNSID(t *testing.T) {
 		return &src
 	}
 	var responseTime time.Time
-	h.Next = test.HandlerFunc(func(c context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	h.Next = test.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		responseTime = time.Now()
 		m := new(dns.Msg)
 		m.SetReply(r)
@@ -85,7 +85,7 @@ func TestNoNSIDRequested(t *testing.T) {
 	rec := dnstest.NewRecorder(w)
 	h, err := NewHandler(false)
 	require.NoError(t, err)
-	h.Next = test.HandlerFunc(func(c context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	h.Next = test.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetReply(r)
 		m.Authoritative = true
@@ -116,7 +116,7 @@ func TestNoEDNSInQuery(t *testing.T) {
 	rec := dnstest.NewRecorder(w)
 	h, err := NewHandler(false)
 	require.NoError(t, err)
-	h.Next = test.HandlerFunc(func(c context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	h.Next = test.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetReply(r)
 		m.Authoritative = true
@@ -147,7 +147,7 @@ func TestEDNSIsDisabled(t *testing.T) {
 	rec := dnstest.NewRecorder(w)
 	h, err := NewHandler(false)
 	require.NoError(t, err)
-	h.Next = test.HandlerFunc(func(c context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	h.Next = test.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetReply(r)
 		m.Authoritative = true

--- a/dnswatch/cmd/detailed.go
+++ b/dnswatch/cmd/detailed.go
@@ -33,7 +33,7 @@ Usage example:
   dnswatch detailed
 `,
 
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		ConfigureVerbosity()
 
 		cfg.Detailed = true

--- a/dnswatch/cmd/exporter.go
+++ b/dnswatch/cmd/exporter.go
@@ -36,7 +36,7 @@ Usage example:
   dnswatch exporter --period 3s
 `,
 
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		ConfigureVerbosity()
 
 		cfg.Exporter = true

--- a/dnswatch/cmd/nettop.go
+++ b/dnswatch/cmd/nettop.go
@@ -35,7 +35,7 @@ Usage example:
   dnswatch nettop --period 3s
 `,
 
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		ConfigureVerbosity()
 
 		cfg.NetTop = true

--- a/dnswatch/cmd/snoop.go
+++ b/dnswatch/cmd/snoop.go
@@ -39,7 +39,7 @@ var snoopCmd = &cobra.Command{
 Usage example:
   dnswatch snoop --list PID,PNAME,QNAME,RIP
 `,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		ConfigureVerbosity()
 
 		if err := snoop.Run(&cfg); err != nil {

--- a/dnswatch/cmd/sql.go
+++ b/dnswatch/cmd/sql.go
@@ -37,7 +37,7 @@ Usage example:
   dnswatch sql --csv /tmp/dnswatch_out --period 30s --orderby -LATENCY --groupby PNAME,QNAME
 `,
 
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		ConfigureVerbosity()
 
 		if cfg.Csv == "" {

--- a/dnswatch/cmd/top.go
+++ b/dnswatch/cmd/top.go
@@ -35,7 +35,7 @@ Usage example:
   dnswatch top --period 3s
 `,
 
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		ConfigureVerbosity()
 
 		cfg.Toplike = true

--- a/dnswatch/snoop/nettop.go
+++ b/dnswatch/snoop/nettop.go
@@ -16,7 +16,6 @@ package snoop
 import (
 	"fmt"
 	"math"
-	"math/rand"
 	"sort"
 	"time"
 
@@ -259,8 +258,6 @@ func (t *NetTopState) refreshScreen() {
 
 // StartNetTop is the nettop stdout handler
 func StartNetTop(refreshChan <-chan map[UniqueDNS]*DisplayInfo, stopChan chan<- bool, refTime time.Duration) {
-	rand.Seed(time.Now().UnixNano())
-
 	err := termbox.Init()
 	if err != nil {
 		log.Error("failed to set up screen")

--- a/dnswatch/snoop/probe.go
+++ b/dnswatch/snoop/probe.go
@@ -156,7 +156,7 @@ func determineHostByteOrder() binary.ByteOrder {
 func (p *Probe) loadAndAttachProbes() (*libbpfgo.Module, error) {
 	libbpfgo.SetLoggerCbs(libbpfgo.Callbacks{
 		LogFilters: []func(libLevel int, msg string) bool{
-			func(libLevel int, msg string) bool {
+			func(_ int, _ string) bool {
 				return !p.Debug
 			},
 		},

--- a/dnswatch/snoop/toplike.go
+++ b/dnswatch/snoop/toplike.go
@@ -16,7 +16,6 @@ package snoop
 import (
 	"fmt"
 	"math"
-	"math/rand"
 	"sort"
 	"strconv"
 	"time"
@@ -238,8 +237,6 @@ func (t *ToplikeState) refreshScreen() {
 
 // StartTopLike is the toplike stdout handler
 func StartTopLike(refreshChan <-chan *ToplikeData, stopChan chan<- bool, refTime time.Duration) {
-	rand.Seed(time.Now().UnixNano())
-
 	err := termbox.Init()
 	if err != nil {
 		log.Error("failed to initialize screen")

--- a/goose/main.go
+++ b/goose/main.go
@@ -16,7 +16,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"os"
 	"os/signal"
@@ -84,9 +83,6 @@ func main() {
 	flag.IntVar(&parallelConnections, "parallel-connections", 1, "max number of parallel connections")
 	flag.BoolVar(&reportJSON, "report-json", false, "Report run results to stdout in json format")
 	flag.Parse()
-
-	// Set the seed
-	rand.Seed(time.Now().UTC().UnixNano())
 
 	switch logLevel {
 	case "debug":


### PR DESCRIPTION
Summary: Fix all lint warnings revealed by GitHub CI after go1.22 upgrade

Differential Revision: D54204526


