### PR TITLE
use unsafe.SliceData

### DIFF
--- a/dnsrocks/cgo-rocksdb/helpers.go
+++ b/dnsrocks/cgo-rocksdb/helpers.go
@@ -19,7 +19,6 @@ package rocksdb
 import "C"
 
 import (
-	"reflect"
 	"unsafe"
 )
 
@@ -27,13 +26,11 @@ type charsSlice []*C.char
 type sizeTSlice []C.size_t
 
 func (s charsSlice) c() **C.char {
-	sH := (*reflect.SliceHeader)(unsafe.Pointer(&s))
-	return (**C.char)(unsafe.Pointer(sH.Data))
+	return unsafe.SliceData(s)
 }
 
 func (s sizeTSlice) c() *C.size_t {
-	sH := (*reflect.SliceHeader)(unsafe.Pointer(&s))
-	return (*C.size_t)(unsafe.Pointer(sH.Data))
+	return unsafe.SliceData(s)
 }
 
 type ptrList struct {


### PR DESCRIPTION
Summary:
Replace deprecated stuff with better, newer alternative.
>reflect.SliceHeader has been deprecated since Go 1.21 and an alternative has been available since Go 1.17: Use unsafe.Slice or unsafe.SliceData instead.

Reviewed By: t3lurid3

Differential Revision: D54246748


