### PR TITLE
export RangePoint text representation

### DIFF
--- a/dnsrocks/dnsdata/data.go
+++ b/dnsrocks/dnsdata/data.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/facebook/dns/dnsrocks/dnsdata/quote"
@@ -282,6 +283,14 @@ const (
 	// TypeHTTPS represents HTTPS record type
 	TypeHTTPS WireType = 65
 )
+
+func (m Lmap) String() string {
+	var builder strings.Builder
+	for _, b := range m {
+		fmt.Fprintf(&builder, "\\%03o", b)
+	}
+	return builder.String()
+}
 
 func (w WireType) String() string {
 	switch w {

--- a/dnsrocks/dnsdata/data_marshaltext.go
+++ b/dnsrocks/dnsdata/data_marshaltext.go
@@ -16,7 +16,6 @@ package dnsdata
 import (
 	"bytes"
 	"fmt"
-	"net"
 )
 
 // MarshalText implements encoding.TextMarshaler
@@ -362,29 +361,7 @@ func (r *Rcsmap) MarshalText() (text []byte, err error) {
 
 // MarshalText implements encoding.TextMarshaler
 func (r *Rrangepoint) MarshalText() (text []byte, err error) {
-	pt := r.pt
-	w := new(bytes.Buffer)
-	w.WriteString(string(prefixRangePoint))
-	putlmaptext(w, r.lmap)
-	w.Write(NSEP)
-	ip := pt.To16()
-	b, err := ip.MarshalText()
-	if err != nil {
-		return nil, err
-	}
-	w.Write(b)
-	if !pt.LocIsNull() {
-		w.Write(NSEP)
-		mlen := pt.MaskLen()
-		if ip.To4() != nil {
-			mlen -= (net.IPv6len - net.IPv4len) * 8
-		}
-		fmt.Fprint(w, mlen)
-		w.Write(NSEP)
-		lo := Loc(pt.LocID())
-		putloctext(w, lo)
-	}
-	return w.Bytes(), nil
+	return r.pt.MarshalTextForLmap(r.lmap.String())
 }
 
 // MarshalText implements encoding.TextMarshaler

--- a/dnsrocks/dnsdata/data_test.go
+++ b/dnsrocks/dnsdata/data_test.go
@@ -1687,6 +1687,11 @@ func TestNoEncodeSubnets(t *testing.T) {
 	}
 }
 
+func TestLmapString(t *testing.T) {
+	l := Lmap{97, 1}
+	require.Equal(t, `\141\001`, l.String())
+}
+
 // Benchmarks for various string conversion functions. To execute just them, run:
 // % buck run //dns/fbdns/dnsdata:dnsdata_test-bench -- -test.bench BenchmarkAtoi
 func BenchmarkAtoiFscan(b *testing.B) {

--- a/dnsrocks/dnsdata/rearranger.go
+++ b/dnsrocks/dnsdata/rearranger.go
@@ -70,6 +70,32 @@ func (r RangePoints) String() string {
 	return strings.Join(result, "\n")
 }
 
+// MarshalTextForLmap returns a text representation of these RangePoints, with provided lmap value
+func (p *RangePoint) MarshalTextForLmap(lmap string) (text []byte, err error) {
+	w := new(bytes.Buffer)
+	w.WriteString(string(prefixRangePoint))
+	w.WriteString(lmap)
+	w.Write(NSEP)
+	ip := p.To16()
+	b, err := ip.MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	w.Write(b)
+	if !p.LocIsNull() {
+		w.Write(NSEP)
+		mlen := p.MaskLen()
+		if ip.To4() != nil {
+			mlen -= (net.IPv6len - net.IPv4len) * 8
+		}
+		fmt.Fprint(w, mlen)
+		w.Write(NSEP)
+		lo := Loc(p.LocID())
+		putloctext(w, lo)
+	}
+	return w.Bytes(), nil
+}
+
 // To16 returns 16-byte IP representation of the rangeStart
 func (p *RangePoint) To16() IPv6 {
 	return p.rangeStart

--- a/dnsrocks/dnsdata/rearranger_test.go
+++ b/dnsrocks/dnsdata/rearranger_test.go
@@ -1012,6 +1012,58 @@ func TestIPIncrementByOne(t *testing.T) {
 	}
 }
 
+func TestRangePointMarshalTextForLmap(t *testing.T) {
+	type testCase struct {
+		p    RangePoint
+		lmap string
+		want string
+	}
+	testCases := []testCase{
+		{
+			p: RangePoint{
+				rangeStart: ParseIP("0.0.0.0"),
+				location: rangeLocation{
+					maskLen:     0,
+					locIDIsNull: true,
+				},
+			},
+			lmap: "\\155\\061",
+			want: "!\\155\\061,0.0.0.0",
+		},
+		{
+			p: RangePoint{
+				rangeStart: ParseIP("1.1.1.1"),
+				location: rangeLocation{
+					maskLen:     120,
+					locID:       [2]byte{100, 101},
+					locIDIsNull: false,
+				},
+			},
+			lmap: "\\155\\061",
+			want: "!\\155\\061,1.1.1.1,24,\\144\\145",
+		},
+		{
+			p: RangePoint{
+				rangeStart: ParseIP("2a00:1fa0:42d8::"),
+				location: rangeLocation{
+					maskLen:     64,
+					locID:       [2]byte{97, 1},
+					locIDIsNull: false,
+				},
+			},
+			lmap: "\\105\\028",
+			want: "!\\105\\028,2a00:1fa0:42d8::,64,\\141\\001",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.want, func(t *testing.T) {
+			got, err := tc.p.MarshalTextForLmap(tc.lmap)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, string(got))
+		})
+	}
+}
+
 func assertEqual(t *testing.T, expected net.IP, actual IPv6) {
 	require.Equal(t, []byte(expected), actual[:])
 }


### PR DESCRIPTION
Summary: Allow pure RangePoint to be converted to text form.

Reviewed By: leoleovich

Differential Revision: D54495166


