### PR TITLE
Add a DoS Absorption Handler (take 2)

### DIFF
--- a/dnsrocks/cmd/dnsrocks/dnsrocks.go
+++ b/dnsrocks/cmd/dnsrocks/dnsrocks.go
@@ -37,7 +37,7 @@ import (
 	_ "net/http/pprof"
 )
 
-func setCPU(cpu string) error {
+func setCPU(cpu string) (int, error) {
 	var numCPU int
 
 	availCPU := runtime.NumCPU()
@@ -48,7 +48,7 @@ func setCPU(cpu string) error {
 		pctStr := cpu[:len(cpu)-1]
 		pctInt, err := strconv.Atoi(pctStr)
 		if err != nil || pctInt < 1 || pctInt > 100 {
-			return errors.New("invalid CPU value: percentage must be between 1-100")
+			return -1, errors.New("invalid CPU value: percentage must be between 1-100")
 		}
 		percent = float32(pctInt) / 100
 		numCPU = int(float32(availCPU) * percent)
@@ -56,7 +56,7 @@ func setCPU(cpu string) error {
 		// Number
 		num, err := strconv.Atoi(cpu)
 		if err != nil || num < 1 {
-			return errors.New("invalid CPU value: provide a number or percent greater than 0")
+			return -1, errors.New("invalid CPU value: provide a number or percent greater than 0")
 		}
 		numCPU = num
 	}
@@ -66,7 +66,7 @@ func setCPU(cpu string) error {
 	}
 
 	runtime.GOMAXPROCS(numCPU)
-	return nil
+	return numCPU, nil
 }
 
 func main() {
@@ -150,6 +150,7 @@ Currently two types of trigger files are supported:
 	// Misc
 	pprofconf := cliflags.String("pprof", "", "Address to have the profiler listen on, disabled if empty.")
 	cpu := cliflags.String("cpu", "1", "CPU cap. Accepts percentage or integer.")
+	cliflags.IntVar(&serverConfig.MaxConcurrency, "max-concurrency", -1, "Maximum number of concurrent queries per CPU for each IP (default: unlimited)")
 	logPrefix := cliflags.String("log-prefix", "", "Prefix to use in logger")
 	dnsRecordKeyToValidate := cliflags.String("record-key-to-validate", "", "DNS record key expected to present in DB file.")
 
@@ -193,7 +194,8 @@ Currently two types of trigger files are supported:
 		glog.Infof("go version: %s go arch: %s go OS: %s", runtime.Version(), runtime.GOARCH, runtime.GOOS)
 		os.Exit(0)
 	}
-	failOnErr(setCPU(*cpu), "Error setting number of CPU")
+	serverConfig.NumCPU, err = setCPU(*cpu)
+	failOnErr(err, "Error setting number of CPU")
 
 	// TODO (jifen) this should be deprecated in subsequent
 	// diff since IDN no longer rely on this

--- a/dnsrocks/cmd/dnsrocks/dnsrocks_test.go
+++ b/dnsrocks/cmd/dnsrocks/dnsrocks_test.go
@@ -16,6 +16,7 @@ package main
 import (
 	"os"
 	"path"
+	"runtime"
 	"testing"
 	"time"
 
@@ -46,6 +47,7 @@ func getConfig(tcp bool) fbserver.ServerConfig {
 	serverConfig.ReusePort = 0
 	serverConfig.WhoamiDomain = ""
 	serverConfig.RefuseANY = false
+	serverConfig.NumCPU = runtime.NumCPU()
 	// the default setup should be backward compatible with current spec: 1 IP address and maxanswer not specified
 
 	// DB config

--- a/dnsrocks/fbserver/config.go
+++ b/dnsrocks/fbserver/config.go
@@ -36,6 +36,8 @@ type ServerConfig struct {
 	ReusePort      int
 	MaxTCPQueries  int
 	TCPIdleTimeout time.Duration
+	NumCPU         int
+	MaxConcurrency int
 	ReadTimeout    time.Duration
 	TLSConfig      tlsconfig.TLSConfig
 	HandlerConfig  dnsserver.HandlerConfig

--- a/dnsrocks/throttle/dns_mock.go
+++ b/dnsrocks/throttle/dns_mock.go
@@ -15,7 +15,7 @@ limitations under the License.
 // Source: github.com/miekg/dns (interfaces: PacketConnReader)
 
 // Package ratelimit is a generated GoMock package.
-package ratelimit
+package throttle
 
 import (
 	net "net"

--- a/dnsrocks/throttle/plugin_mock.go
+++ b/dnsrocks/throttle/plugin_mock.go
@@ -15,7 +15,7 @@ limitations under the License.
 // Source: github.com/coredns/coredns/plugin (interfaces: Handler)
 
 // Package ratelimit is a generated GoMock package.
-package ratelimit
+package throttle
 
 import (
 	context "context"

--- a/dnsrocks/throttle/throttle.go
+++ b/dnsrocks/throttle/throttle.go
@@ -1,0 +1,158 @@
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package throttle
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/miekg/dns"
+	"golang.org/x/sync/semaphore"
+)
+
+// Handler is a [plugin.Handler] that limits how many queries
+// are currently being processed.  It should be the first handler in the
+// chain, and must be used with the associated [Reader].
+//
+// Handler does not provide an absolute guarantee, because each
+// query is marked as "completed" just _before_ its goroutine terminates.
+type Handler struct {
+	// A Go semaphore is just a locked FIFO queue.
+	// TODO: Upgrade this to a fair queue.
+	sem  *semaphore.Weighted
+	Next plugin.Handler
+}
+
+// NewHandler initializes a new concurrency-limiting Handler.
+func NewHandler(maxWorkers int) (*Handler, error) {
+	if maxWorkers < 1 {
+		return nil, fmt.Errorf("invalid number of workers: %d", maxWorkers)
+	}
+	return &Handler{
+		sem: semaphore.NewWeighted(int64(maxWorkers)),
+	}, nil
+}
+
+// ServeDNS implements the [plugin.Handler] interface.
+func (h *Handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	defer h.sem.Release(1)
+	return plugin.NextOrFailure(h.Name(), h.Next, ctx, w, r)
+}
+
+// Name returns the handler's name.
+func (h *Handler) Name() string { return "throttle" }
+
+// Acquire must be called before accepting each incoming query packet.
+func (h *Handler) Acquire(ctx context.Context) error {
+	return h.sem.Acquire(ctx, 1)
+}
+
+// DecorateReader is a [dns.DecorateReader].
+func (h *Handler) DecorateReader(inner dns.Reader) dns.Reader {
+	return newReader(inner.(dns.PacketConnReader), h)
+}
+
+// MsgInvalid is a [dns.MsgInvalidFunc].
+func (h *Handler) MsgInvalid([]byte, error) {
+	// If an invalid packet arrives, throttle.Reader will acquire
+	// the semaphore, but ServeDNS will never be called to release it.
+	// Instead, we need to release it here.
+	h.sem.Release(1)
+}
+
+// Attach connects this handler to a Server's message processing path.
+// This method must be called before the server starts.
+func (h *Handler) Attach(s *dns.Server) {
+	s.DecorateReader = h.DecorateReader
+	s.MsgInvalidFunc = h.MsgInvalid
+}
+
+// Reader is a [dns.Reader] that blocks when
+// the concurrency exceeds some threshold.
+type Reader struct {
+	inner   dns.PacketConnReader
+	handler *Handler
+}
+
+func newReader(inner dns.PacketConnReader, handler *Handler) *Reader {
+	return &Reader{
+		inner:   inner,
+		handler: handler,
+	}
+}
+
+func (r *Reader) acquire(deadline time.Time) error {
+	ctx := context.Background()
+	if !deadline.IsZero() {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(ctx, deadline)
+		defer cancel()
+	}
+	return r.handler.Acquire(ctx)
+}
+
+func deadline(timeout time.Duration) time.Time {
+	if timeout > 0 {
+		return time.Now().Add(timeout)
+	}
+	return time.Time{}
+}
+
+// ReadUDP implements [dns.Reader].
+func (r *Reader) ReadUDP(conn *net.UDPConn, timeout time.Duration) ([]byte, *dns.SessionUDP, error) {
+	deadline := deadline(timeout)
+	queryBuf, s, err := r.inner.ReadUDP(conn, timeout)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err = r.acquire(deadline); err != nil {
+		return nil, nil, err
+	}
+
+	return queryBuf, s, nil
+}
+
+// ReadPacketConn implements [dns.PacketConnReader].
+func (r *Reader) ReadPacketConn(conn net.PacketConn, timeout time.Duration) ([]byte, net.Addr, error) {
+	deadline := deadline(timeout)
+	queryBuf, addr, err := r.inner.ReadPacketConn(conn, timeout)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err = r.acquire(deadline); err != nil {
+		return nil, nil, err
+	}
+
+	return queryBuf, addr, nil
+}
+
+// ReadTCP implements [dns.Reader].
+func (r *Reader) ReadTCP(conn net.Conn, timeout time.Duration) ([]byte, error) {
+	deadline := deadline(timeout)
+	queryBuf, err := r.inner.ReadTCP(conn, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = r.acquire(deadline); err != nil {
+		return nil, err
+	}
+
+	return queryBuf, nil
+}

--- a/dnsrocks/throttle/throttle_test.go
+++ b/dnsrocks/throttle/throttle_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package throttle
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
+)
+
+func TestConcurrencyReader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h, err := NewHandler(3)
+	require.NoError(t, err)
+	next := NewMockHandler(ctrl)
+	h.Next = next
+	innerReader := NewMockPacketConnReader(ctrl)
+	reader := h.DecorateReader(innerReader)
+	var conn net.PacketConn
+
+	var buf [32]byte
+	addr := &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 1234}
+
+	doWrite := make(chan struct{})
+	sem := semaphore.NewWeighted(3)
+
+	innerReader.EXPECT().ReadPacketConn(conn, time.Duration(0)).Times(10).Return(buf[:], addr, nil)
+	next.EXPECT().Name().AnyTimes().Return("mock")
+	next.EXPECT().ServeDNS(gomock.Any(), gomock.Any(), gomock.Any()).Times(10).Do(func(_, _, _ interface{}) {
+		require.True(t, sem.TryAcquire(1), "Too many concurrent requests")
+		<-doWrite
+		sem.Release(1)
+	})
+
+	go func() {
+		for i := 0; i < 10; i++ {
+			outBuf, outAddr, err := reader.(dns.PacketConnReader).ReadPacketConn(conn, 0)
+			require.NoError(t, err)
+			require.Equal(t, &buf[0], &outBuf[0])
+			require.Equal(t, outAddr, addr)
+			go func() {
+				_, err := h.ServeDNS(context.Background(), nil, nil)
+				require.NoError(t, err)
+			}()
+		}
+	}()
+
+	// Wait for three concurrent requests to be issued.
+	for sem.TryAcquire(1) {
+		sem.Release(1)
+		time.Sleep(time.Millisecond)
+	}
+
+	for i := 0; i < 10; i++ {
+		doWrite <- struct{}{}
+	}
+}
+
+// Verify that context cancellation causes Acquire() to return early
+// with an error.
+func TestContext(t *testing.T) {
+	h, err := NewHandler(3)
+	require.NoError(t, err)
+
+	for range 3 {
+		err = h.Acquire(context.Background())
+		require.NoError(t, err)
+	}
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = h.Acquire(canceled)
+	require.Error(t, err)
+}
+
+func TestMsgInvalid(t *testing.T) {
+	h, err := NewHandler(3)
+	require.NoError(t, err)
+
+	// This handler is limited to three concurrent requests,
+	// but calling MsgInvalid decrements the counter so we can
+	// do this loop as many times as we want.
+	for range 10 {
+		err = h.Acquire(context.Background())
+		require.NoError(t, err)
+		h.MsgInvalid(nil, nil)
+	}
+}


### PR DESCRIPTION
Summary: This diff adds an additional handler to the processing chain that limits the number of concurrently processed requests per CPU.

Reviewed By: abulimov

Differential Revision: D59345860
