### PR TITLE
Stop session ticket refresh at server stop

### DIFF
--- a/dnsrocks/tlsconfig/common.go
+++ b/dnsrocks/tlsconfig/common.go
@@ -26,7 +26,7 @@ type CryptoSSLConfig struct {
 // SessionTicketKeysConfig contains the config for handling session resumption
 type SessionTicketKeysConfig struct {
 	SeedFile               string
-	SeedFileReloadInterval int
+	SeedFileReloadInterval int // seconds, 0 to disable reload
 }
 
 // TLSConfig contains config for a given TLS Listener


### PR DESCRIPTION
Summary:
FBDNS supports DNS over TLS, and periodically reloads its TLS Session Tickets from a shared cache to support TLS Session Resumption.  The goroutine responsible for this reload is supposed to run until a "quit" channel is closed.  However, this channel is never closed, so the goroutine, and the TLS config it maintains, will leak if the server is ever stopped.

In typical use, an FBDNS server only stops when the process is being shut down, so this is not a problem in production, but it is a correctness issue, and could become relevant in any environments where the server is being restarted in a long-lived process.

Reviewed By: abulimov

Differential Revision: D61350816
