### PR TITLE
Fix lint errors

### DIFF
--- a/dnswatch/snoop/probe.go
+++ b/dnswatch/snoop/probe.go
@@ -16,6 +16,7 @@ package snoop
 import (
 	"bytes"
 	_ "embed" // Embed needs to be imported for the []byte containing the embedded Bpf object
+	"errors"
 
 	"encoding/binary"
 
@@ -182,7 +183,7 @@ func (p *Probe) loadAndAttachProbes() (*libbpfgo.Module, error) {
 			return nil, fmt.Errorf("unable attaching fentry/"+kernelFnName+": %w", err)
 		}
 		if kprobelink.FileDescriptor() == 0 {
-			return nil, fmt.Errorf("kprobe/" + kernelFnName + "not running.")
+			return nil, errors.New("kprobe/" + kernelFnName + "not running.")
 		}
 	}
 	return bpfModule, nil

--- a/dnswatch/snoop/snoop.go
+++ b/dnswatch/snoop/snoop.go
@@ -337,7 +337,7 @@ func (c *Consumer) handleOutputSetup() {
 		go startPrometheusExporter(c.exporterQueue, c.Config.ExporterListen)
 		return
 	}
-	log.Infof(DisplayHeader(c.Fields))
+	log.Info(DisplayHeader(c.Fields))
 }
 
 func (c *Consumer) handlePrint(d *DisplayInfo) {
@@ -346,10 +346,10 @@ func (c *Consumer) handlePrint(d *DisplayInfo) {
 		return
 	}
 	if c.Config.Detailed {
-		log.Infof(d.DetailedString())
+		log.Info(d.DetailedString())
 		return
 	}
-	log.Infof(d.String())
+	log.Info(d.String())
 }
 
 func (c *Consumer) handleRefresh() {


### PR DESCRIPTION
Summary: The lint_dnswatch Github Action is failing.  Perhaps there was a recent update to `go vet` there.

Reviewed By: pmazzini

Differential Revision: D61472598
