### PR TITLE
Correct FindSOA behavior for extended location IDs

### DIFF
--- a/dnsrocks/db/db.go
+++ b/dnsrocks/db/db.go
@@ -343,7 +343,7 @@ func (r *sortedDataReader) ForEachResourceRecord(domainName []byte, locID ID, pa
 	locationIndex := len(dnsdata.ResourceRecordsKeyMarker) + len(domainName)
 
 	if !locID.IsZero() {
-		copy(key[locationIndex:], locID)
+		key = append(key[:locationIndex], locID...)
 		err = r.ForEach(key, parseRecord)
 		if err != nil {
 			glog.Errorf("Error %v", err)
@@ -351,7 +351,7 @@ func (r *sortedDataReader) ForEachResourceRecord(domainName []byte, locID ID, pa
 		}
 	}
 
-	copy(key[locationIndex:], ZeroID)
+	key = append(key[:locationIndex], ZeroID...)
 	err = r.ForEach(key, parseRecord)
 	if err != nil {
 		glog.Errorf("Error %v", err)


### PR DESCRIPTION
Summary: This change corrects a logic error in `FindSOA` when extended location IDs are used.

Reviewed By: abulimov

Differential Revision: D64396637


