### PR TITLE
Clean up variable use and logger abstraction

### DIFF
--- a/dnsrocks/db/cdbdriver.go
+++ b/dnsrocks/db/cdbdriver.go
@@ -249,13 +249,15 @@ func (c *cdbdriver) ForEach(key []byte, f func(value []byte) error, context Cont
 
 	c.FindStart(context)
 	for {
-		v, err := c.FindNext(key, context)
+		// only return non-EOF errors
+		v, findNextErr := c.FindNext(key, context)
 
 		// No more row
-		if errors.Is(err, io.EOF) {
+		if errors.Is(findNextErr, io.EOF) {
 			break
 		}
-		if err != nil {
+		if findNextErr != nil {
+			err = findNextErr
 			break
 		}
 		if err = f(v); err != nil {

--- a/dnsrocks/db/db.go
+++ b/dnsrocks/db/db.go
@@ -71,7 +71,7 @@ type DB struct {
 type Reader interface {
 	FindLocation(qname []byte, m *dns.Msg, ip string) (ecs *dns.EDNS0_SUBNET, loc *Location, err error)
 	IsAuthoritative(q []byte, locID ID) (ns bool, auth bool, zoneCut []byte, err error)
-	FindAnswer(q []byte, packedControlName []byte, qname string, qtype uint16, locID ID, a *dns.Msg, maxAnswer int) (bool, bool)
+	FindAnswer(q []byte, packedControlName []byte, qname string, qtype uint16, locID ID, a *dns.Msg, maxAnswer int) (bool, int)
 
 	EcsLocation(q []byte, ecs *dns.EDNS0_SUBNET) (*Location, error)
 	ResolverLocation(q []byte, ip string) (*Location, error)

--- a/dnsrocks/dnsserver/handler.go
+++ b/dnsrocks/dnsserver/handler.go
@@ -318,8 +318,6 @@ func (h *FBDNSDB) ServeDNSWithRCODE(ctx context.Context, w dns.ResponseWriter, r
 		a.Authoritative = false
 		h.stats.IncrementCounter("DNS_response.not_authoritative")
 	} else {
-		// For NXDOMAIN
-		recordFound := false
 		h.stats.IncrementCounter("DNS_response.authoritative")
 
 		maxAns, ok := GetMaxAnswer(ctx)
@@ -327,10 +325,7 @@ func (h *FBDNSDB) ServeDNSWithRCODE(ctx context.Context, w dns.ResponseWriter, r
 			maxAns = DefaultMaxAnswer
 			// log something
 		}
-		weighted, recordFound = reader.FindAnswer(packedQName, zoneCut, state.QName(), state.QType(), loc.LocID, a, maxAns)
-		if len(a.Answer) == 0 && !recordFound {
-			a.Rcode = dns.RcodeNameError
-		}
+		weighted, a.Rcode = reader.FindAnswer(packedQName, zoneCut, state.QName(), state.QType(), loc.LocID, a, maxAns)
 	}
 
 	unpackedControlDomain, _, err := dns.UnpackDomainName(zoneCut, 0)

--- a/dnsrocks/dnsserver/logger.go
+++ b/dnsrocks/dnsserver/logger.go
@@ -27,7 +27,7 @@ import (
 // Logger is an interface for logging messages
 type Logger interface {
 	// LogFailed logs a message when we could not construct an answer
-	LogFailed(state request.Request, r *dns.Msg, ecs *dns.EDNS0_SUBNET, loc *db.Location)
+	LogFailed(state request.Request, ecs *dns.EDNS0_SUBNET, loc *db.Location)
 	// Log logs a DNS response
 	Log(state request.Request, r *dns.Msg, ecs *dns.EDNS0_SUBNET, loc *db.Location)
 }
@@ -45,9 +45,9 @@ func (l *TextLogger) Log(state request.Request, _ *dns.Msg, _ *dns.EDNS0_SUBNET,
 }
 
 // LogFailed is used to log failures
-func (l *TextLogger) LogFailed(state request.Request, r *dns.Msg, ecs *dns.EDNS0_SUBNET, loc *db.Location) {
+func (l *TextLogger) LogFailed(state request.Request, ecs *dns.EDNS0_SUBNET, loc *db.Location) {
 	m := new(dns.Msg)
-	m.SetRcode(r, dns.RcodeServerFailure)
+	m.SetRcode(state.Req, dns.RcodeServerFailure)
 	l.Log(state, m, ecs, loc)
 }
 
@@ -58,5 +58,5 @@ type DummyLogger struct{}
 func (l *DummyLogger) Log(_ request.Request, _ *dns.Msg, _ *dns.EDNS0_SUBNET, _ *db.Location) {}
 
 // LogFailed is used to log failures
-func (l *DummyLogger) LogFailed(_ request.Request, _ *dns.Msg, _ *dns.EDNS0_SUBNET, _ *db.Location) {
+func (l *DummyLogger) LogFailed(_ request.Request, _ *dns.EDNS0_SUBNET, _ *db.Location) {
 }

--- a/dnsrocks/logger/dnstap_logger.go
+++ b/dnsrocks/logger/dnstap_logger.go
@@ -160,8 +160,8 @@ func (l *DNSTapLogger) Log(state request.Request, r *dns.Msg, _ *dns.EDNS0_SUBNE
 }
 
 // LogFailed is used to log failures
-func (l *DNSTapLogger) LogFailed(state request.Request, r *dns.Msg, ecs *dns.EDNS0_SUBNET, loc *db.Location) {
+func (l *DNSTapLogger) LogFailed(state request.Request, ecs *dns.EDNS0_SUBNET, loc *db.Location) {
 	m := new(dns.Msg)
-	m.SetRcode(r, dns.RcodeServerFailure)
+	m.SetRcode(state.Req, dns.RcodeServerFailure)
 	l.Log(state, m, ecs, loc)
 }

--- a/dnsrocks/testdata/data/data.nets
+++ b/dnsrocks/testdata/data/data.nets
@@ -107,6 +107,8 @@ Cwww.example.com,www.nonauth.example.com,3600,,
 Cwww2.example.com,foo.example.com,3600,,
 Cwww3.example.com,bar.example.com,3600,,
 
+Cinvalid-target.example.com,longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong.com,3600,,
+
 Hfoo.example.com,.,7200,,1,alpn=h3|h2|http/1.1
 Hfoo.example.com,fallback.foo.example.com,7200,,2,alpn=h3|h2|http/1.1
 +foo.example.com,1.1.1.1,180,,\000\001,1


### PR DESCRIPTION
Summary:
As I was trying to abstract away logic into helper functions to enable CNAME chasing, I realized there was a redundancy in variables passed to the helper function. `state.Req` held the same value as `r`. This diff aims to clean that up by using the `state` variable where possible.

It also cleaned up the call to the `LogFailed` function which doesn't need to be passed in a `*dns.Msg`, `state.Req` already contains this value.

Differential Revision: D64629679


