### PR TITLE
Add -cname-chasing option

### DIFF
--- a/dnsrocks/cmd/dnsrocks/dnsrocks.go
+++ b/dnsrocks/cmd/dnsrocks/dnsrocks.go
@@ -151,6 +151,7 @@ Currently two types of trigger files are supported:
 	pprofconf := cliflags.String("pprof", "", "Address to have the profiler listen on, disabled if empty.")
 	cpu := cliflags.String("cpu", "1", "CPU cap. Accepts percentage or integer.")
 	cliflags.IntVar(&serverConfig.MaxConcurrency, "max-concurrency", -1, "Maximum number of concurrent queries per CPU (default: unlimited)")
+	cliflags.BoolVar(&serverConfig.CNAMEChasing, "cname-chasing", false, "Whether or not to do CNAME chasing. (default: disabled)")
 	logPrefix := cliflags.String("log-prefix", "", "Prefix to use in logger")
 	dnsRecordKeyToValidate := cliflags.String("record-key-to-validate", "", "DNS record key expected to present in DB file.")
 

--- a/dnsrocks/fbserver/cnamechasing.go
+++ b/dnsrocks/fbserver/cnamechasing.go
@@ -1,0 +1,42 @@
+/*
+Copyright (c) Meta Platforms, Inc. and affiliates.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fbserver
+
+import (
+	"context"
+
+	"github.com/facebook/dns/dnsrocks/dnsserver"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/miekg/dns"
+)
+
+type cnameChasingHandler struct {
+	Next plugin.Handler
+}
+
+// newCNAMEChasingHandler initializes a new cnameChasingHandler.
+// This handler is used to control whether CNAME chasing is
+// enabled/disabled in the server.
+func newCNAMEChasingHandler() (*cnameChasingHandler, error) {
+	ch := new(cnameChasingHandler)
+	return ch, nil
+}
+
+func (ch *cnameChasingHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	ctx = dnsserver.WithCNAMEChasing(ctx, true)
+	return plugin.NextOrFailure(ch.Name(), ch.Next, ctx, w, r)
+}
+
+func (ch *cnameChasingHandler) Name() string { return "cnameChasing" }

--- a/dnsrocks/fbserver/config.go
+++ b/dnsrocks/fbserver/config.go
@@ -48,6 +48,7 @@ type ServerConfig struct {
 	DNSSECConfig   DNSSECConfig
 	NSID           bool
 	PrivateInfo    bool
+	CNAMEChasing   bool
 }
 
 type ipAns map[string]int


### PR DESCRIPTION
Summary: Add a -cname-chasing command-line argument to fbdns. This allows us to control whether CNAME chasing in enabled or not.

Differential Revision: D64804019


