### PR TITLE
Fix lint

### DIFF
--- a/dnsrocks/dnsdata/rearranger.go
+++ b/dnsrocks/dnsdata/rearranger.go
@@ -161,7 +161,7 @@ var ErrInvalidLocation = errors.New("location should be either nil or exactly 2 
 func copyLocID(locID []byte) ([]byte, error) {
 	var x = make([]byte, len(locID))
 
-	if locID == nil || len(locID) < 2 {
+	if len(locID) < 2 {
 		return x, fmt.Errorf("%w. location value '%v'", ErrInvalidLocation, locID)
 	}
 	copy(x, locID)


### PR DESCRIPTION
Summary:
Lint error broke CI:
```
Run golangci/golangci-lint-action@v3: dnsrocks/dnsdata/rearranger.go#L164
S1009: should omit nil check; len() for nil slices is defined as zero (gosimple)
```

Differential Revision: D71162315


